### PR TITLE
Read values from Virtuaaliviivakoodi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 dist
 .DS_Store
+.venv
+.idea

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
-Virtuaaliviivakoodi is a Python library for generating virtual barcodes based on Finanssiala's [pankkiviivakoodi spec](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf).
+Virtuaaliviivakoodi is a Python library for generating and deconstructing virtual barcodes based on Finanssiala's [pankkiviivakoodi spec](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf).
 
 ## Installation
 
@@ -16,6 +16,8 @@ pip install virtuaaliviivakoodi
 ```
 
 ## Usage
+
+### Creating a virtual barcode
 
 ```python
 from virtuaaliviivakoodi import virtuaaliviivakoodi
@@ -31,14 +33,36 @@ virtuaaliviivakoodi(
 
 ```
 
+### Deconstructing a virtual barcode
+
+```python
+from virtuaaliviivakoodi import deconstruct_virtuaaliviivakoodi
+
+deconstruct = deconstruct_virtuaaliviivakoodi("449500094200287300001002000000000000001234567907201212")
+
+# > deconstruct.symbol = SymbolVersion.VERSION_4,
+#   deconstruct.iban = FI4950009420028730,
+#   deconstruct.euro_amount = Decimal('100.20'),
+#   deconstruct.reference = 1234567907,
+#   deconstruct.due_date = date(2022, 12, 12),
+```
+
 ## Function arguments
 
-| Argument      | Type          | Description                                                                                                                                                                                                   |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `iban`        | `str`         | Mandatory. Payment receiver's IBAN. Must be in Finnish format. E.g.: `"FI49 5000 9420 0287 30"` or `"FI4950009420028730"`                                                                                     |
-| `reference`   | `str` `int`   | Mandatory. Invoice reference in Finnish or international (RF) format. May invluce whitespace characters. E.g. `"12345 67907"`, `"1234567907"`, `1234567907` or `"RF92 1234 2345"`                             |
-| `due_date`    | `date`        | Mandatory. Invoice due date as a Python date object.                                                                                                                                                          |
-| `euro_amount` | `float` `int` | Mandatory. Invoice total amount in Euros. Must be positive number. According [the spec](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf) amount must be smaller than 1000000. |
+### Creating a virtual barcode
+
+| Argument      | Type                    | Description                                                                                                                                                                                                   |
+| ------------- |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `iban`        | `str`                   | Mandatory. Payment receiver's IBAN. Must be in Finnish format. E.g.: `"FI49 5000 9420 0287 30"` or `"FI4950009420028730"`                                                                                     |
+| `reference`   | `str` `int`             | Mandatory. Invoice reference in Finnish or international (RF) format. May invluce whitespace characters. E.g. `"12345 67907"`, `"1234567907"`, `1234567907` or `"RF92 1234 2345"`                             |
+| `euro_amount` | `float` `int` `Decimal` | Mandatory. Invoice total amount in Euros. Must be positive number. According [the spec](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf) amount must be smaller than 1000000. |
+| `due_date`    | `date`                  | Optional. Invoice due date as a Python date object. If left empty, `"000000"` is used as the date according to [the spec](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf)                                                                                       |
+
+### Deconstructing a virtual barcode
+
+| Argument              | Type                    | Description                                                                                                     |
+|-----------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `virtuaaliviivakoodi` | `str`                   | Mandatory. Virtuaaliviivakoodi to deconstruct. E.g.: `"449500094200287300001002000000000000001234567907201212"` |
 
 ## Exceptions
 
@@ -46,18 +70,22 @@ Exceptions can be imported the following way:
 
 ```python
 from virtuaaliviivakoodi.exceptions import (
-	VirtuaaliviivakoodiException,
-	InvalidIBANException,
-	InvalidReferenceException,
-	InvalidEuroAmountException,
-	InvalidDueDateException,
+        VirtuaaliviivakoodiException,
+        InvalidIBANException,
+        InvalidReferenceException,
+        InvalidEuroAmountException,
+        InvalidDueDateException,
+        InvalidSymbolException,
+        InvalidLengthException
 )
 ```
 
-| Exception                      | Description                                               |
-| ------------------------------ | --------------------------------------------------------- |
-| `VirtuaaliviivakoodiException` | Base exception class for all of the following exceptions. |
-| `InvalidIBANException`         | Raised for invalid IBANs                                  |
-| `InvalidReferenceException`    | Raised for invalid references                             |
-| `InvalidEuroAmountException`   | Raised for invalid euro amounts                           |
-| `InvalidDueDateException`      | Raised for invalid due dates                              |
+| Exception                      | Description                                                  |
+|--------------------------------|--------------------------------------------------------------|
+| `VirtuaaliviivakoodiException` | Base exception class for all of the following exceptions.    |
+| `InvalidIBANException`         | Raised for invalid IBANs                                     |
+| `InvalidReferenceException`    | Raised for invalid references                                |
+| `InvalidEuroAmountException`   | Raised for invalid euro amounts                              |
+| `InvalidDueDateException`      | Raised for invalid due dates                                 |
+| `InvalidSymbolException`       | Raised for invalid symbol version of the virtuaaliviivakoodi |
+| `InvalidLengthException`       | Raised for invalid length of the virtuaaliviivakoodi         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "virtuaaliviivakoodi"
-version = "1.0.1"
-description = "Python library for generating Finnish virtuaaliviivakoodi's"
+version = "1.1.0"
+description = "Python library for generating and reading Finnish virtuaaliviivakoodi's"
 authors = ["Juho Enala <juho.enala@nocfo.io>"]
 readme = "README.md"
 license = "MIT"

--- a/tests/test_virtuaaliviivakoodi_deconstruct.py
+++ b/tests/test_virtuaaliviivakoodi_deconstruct.py
@@ -4,12 +4,11 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from virtuaaliviivakoodi import virtuaaliviivakoodi
+from virtuaaliviivakoodi import deconstruct_virtuaaliviivakoodi
+from virtuaaliviivakoodi.constants import SymbolVersion
 from virtuaaliviivakoodi.exceptions import (
-    InvalidEuroAmountException,
-    InvalidIBANException,
-    InvalidReferenceException,
-    VirtuaaliviivakoodiException,
+    InvalidLengthException,
+    InvalidSymbolException,
 )
 
 
@@ -18,55 +17,21 @@ class TestVirtuaaliviivakoodi(TestCase):
         [
             (
                 {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "12 34561",
-                    "euro_amount": 124.12,
-                    "due_date": date(2022, 2, 2),
-                },
-                "449500094200287300001241200000000000000001234561220202",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "12 34561",
+                    "iban": "FI4950009420028730",
+                    "reference": "1234561",
                     "euro_amount": decimal.Decimal("124.12"),
                     "due_date": date(2022, 2, 2),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "449500094200287300001241200000000000000001234561220202",
             ),
             (
                 {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "12 34561",
-                    "euro_amount": decimal.Decimal("0.01"),
+                    "iban": "FI4950009420028730",
+                    "reference": "1234561",
+                    "euro_amount": decimal.Decimal("124.12"),
                     "due_date": date(2022, 2, 2),
-                },
-                "449500094200287300000000100000000000000001234561220202",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "12 34561",
-                    "euro_amount": decimal.Decimal("999999.99"),
-                    "due_date": date(2022, 2, 2),
-                },
-                "449500094200287309999999900000000000000001234561220202",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "12 34561",
-                    "euro_amount": decimal.Decimal("0.00"),
-                    "due_date": date(2022, 2, 2),
-                },
-                "449500094200287300000000000000000000000001234561220202",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": 1234561,
-                    "euro_amount": 124.12,
-                    "due_date": date(2022, 2, 2),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "449500094200287300001241200000000000000001234561220202",
             ),
@@ -74,35 +39,39 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI4950009420028730",
                     "reference": "7777776",
-                    "euro_amount": 2222.55,
+                    "euro_amount": decimal.Decimal("2222.55"),
                     "due_date": date(2020, 12, 12),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "449500094200287300022225500000000000000007777776201212",
             ),
             (
                 {
                     "iban": "FI4950009420028730",
-                    "reference": "RF92 1234 2345",
-                    "euro_amount": 2222.55,
+                    "reference": "RF9212342345",
+                    "euro_amount": decimal.Decimal("2222.55"),
                     "due_date": date(2020, 12, 12),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "549500094200287300022225592000000000000012342345201212",
             ),
             (
                 {
                     "iban": "FI4950009420028730",
-                    "reference": "RF92 1234 2345",
-                    "euro_amount": 999999.99,
+                    "reference": "RF9212342345",
+                    "euro_amount": decimal.Decimal("999999.99"),
                     "due_date": date(2020, 12, 12),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "549500094200287309999999992000000000000012342345201212",
             ),
             (
                 {
-                    "iban": "FI49 5000 9420 0287 30",
+                    "iban": "FI4950009420028730",
                     "reference": "RF07999999999993",
-                    "euro_amount": 0,
+                    "euro_amount": decimal.Decimal(0),
                     "due_date": date(2020, 12, 12),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "549500094200287300000000007000000000999999999993201212",
             ),
@@ -110,8 +79,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI7944052020036082",
                     "reference": "868516259619897",
-                    "euro_amount": 4883.15,
+                    "euro_amount": decimal.Decimal("4883.15"),
                     "due_date": date(2010, 6, 12),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "479440520200360820048831500000000868516259619897100612",
             ),
@@ -119,8 +89,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI5810171000000122",
                     "reference": "559582243294671",
-                    "euro_amount": 482.99,
+                    "euro_amount": decimal.Decimal("482.99"),
                     "due_date": date(2012, 1, 31),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "458101710000001220004829900000000559582243294671120131",
             ),
@@ -128,8 +99,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI0250004640001302",
                     "reference": "69875672083435364",
-                    "euro_amount": 693.80,
+                    "euro_amount": decimal.Decimal("693.80"),
                     "due_date": date(2011, 7, 24),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "402500046400013020006938000000069875672083435364110724",
             ),
@@ -137,8 +109,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI1566010001530641",
                     "reference": "7758474790647489",
-                    "euro_amount": 7444.54,
+                    "euro_amount": decimal.Decimal("7444.54"),
                     "due_date": date(2019, 12, 19),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "415660100015306410074445400000007758474790647489191219",
             ),
@@ -146,7 +119,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI1680001400050267",
                     "reference": "78777679656628687",
-                    "euro_amount": 935.85,
+                    "euro_amount": decimal.Decimal("935.85"),
+                    "due_date": None,
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "416800014000502670009358500000078777679656628687000000",
             ),
@@ -154,8 +129,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI7331313001000058",
                     "reference": "868624",
-                    "euro_amount": 0.00,
+                    "euro_amount": decimal.Decimal("0.00"),
                     "due_date": date(2013, 8, 9),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "473313130010000580000000000000000000000000868624130809",
             ),
@@ -163,8 +139,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI8333010001100775",
                     "reference": "92125374252539897737",
-                    "euro_amount": 150000.20,
+                    "euro_amount": decimal.Decimal("150000.20"),
                     "due_date": date(2016, 5, 25),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "483330100011007751500002000092125374252539897737160525",
             ),
@@ -172,8 +149,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI3936363002092492",
                     "reference": "590738390",
-                    "euro_amount": 1.03,
+                    "euro_amount": decimal.Decimal("1.03"),
                     "due_date": date(2023, 3, 11),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "439363630020924920000010300000000000000590738390230311",
             ),
@@ -181,8 +159,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI9239390001003391",
                     "reference": "1357914",
-                    "euro_amount": 0.02,
+                    "euro_amount": decimal.Decimal("0.02"),
                     "due_date": date(2099, 12, 24),
+                    "version": SymbolVersion.VERSION_4,
                 },
                 "492393900010033910000000200000000000000001357914991224",
             ),
@@ -190,8 +169,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI7944052020036082",
                     "reference": "RF09868516259619897",
-                    "euro_amount": 4883.15,
+                    "euro_amount": decimal.Decimal("4883.15"),
                     "due_date": date(2010, 6, 12),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "579440520200360820048831509000000868516259619897100612",
             ),
@@ -199,8 +179,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI5810171000000122",
                     "reference": "RF06559582243294671",
-                    "euro_amount": 482.99,
+                    "euro_amount": decimal.Decimal("482.99"),
                     "due_date": date(2010, 1, 31),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "558101710000001220004829906000000559582243294671100131",
             ),
@@ -208,8 +189,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI0250004640001302",
                     "reference": "RF61698756720839",
-                    "euro_amount": 693.80,
+                    "euro_amount": decimal.Decimal("693.80"),
                     "due_date": date(2011, 7, 24),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "502500046400013020006938061000000000698756720839110724",
             ),
@@ -217,8 +199,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI1566010001530641",
                     "reference": "RF847758474790647489",
-                    "euro_amount": 7444.54,
+                    "euro_amount": decimal.Decimal("7444.54"),
                     "due_date": date(2019, 12, 19),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "515660100015306410074445484000007758474790647489191219",
             ),
@@ -226,8 +209,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI1680001400050267",
                     "reference": "RF6078777679656628687",
-                    "euro_amount": 935.85,
+                    "euro_amount": decimal.Decimal("935.85"),
                     "due_date": None,
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "516800014000502670009358560000078777679656628687000000",
             ),
@@ -235,8 +219,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI7331313001000058",
                     "reference": "RF10868624",
-                    "euro_amount": 0.0,
+                    "euro_amount": decimal.Decimal("0.0"),
                     "due_date": date(2013, 8, 9),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "573313130010000580000000010000000000000000868624130809",
             ),
@@ -244,8 +229,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI8333010001100775",
                     "reference": "RF7192125374252539897737",
-                    "euro_amount": 150000.20,
+                    "euro_amount": decimal.Decimal("150000.20"),
                     "due_date": date(2016, 5, 25),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "583330100011007751500002071092125374252539897737160525",
             ),
@@ -253,8 +239,9 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI3936363002092492",
                     "reference": "RF66590738390",
-                    "euro_amount": 1.03,
+                    "euro_amount": decimal.Decimal("1.03"),
                     "due_date": date(2023, 3, 11),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "539363630020924920000010366000000000000590738390230311",
             ),
@@ -262,96 +249,54 @@ class TestVirtuaaliviivakoodi(TestCase):
                 {
                     "iban": "FI9239390001003391",
                     "reference": "RF951357914",
-                    "euro_amount": 0.02,
+                    "euro_amount": decimal.Decimal("0.02"),
                     "due_date": date(2099, 12, 24),
+                    "version": SymbolVersion.VERSION_5,
                 },
                 "592393900010033910000000295000000000000001357914991224",
             ),
         ]
     )
-    def test_valid_virtuaaliviivakoodis(self, options, expected_result):
-        self.assertEqual(virtuaaliviivakoodi(**options), expected_result)
+    def test_valid_virtuaaliviivakoodis_deconstruct(
+        self, expected_result, virtuaaliviivakoodi
+    ):
+
+        deconstruct = deconstruct_virtuaaliviivakoodi(virtuaaliviivakoodi)
+
+        result = {
+            "version": deconstruct.symbol,
+            "iban": deconstruct.iban,
+            "euro_amount": deconstruct.euro_amount,
+            "reference": deconstruct.reference,
+            "due_date": deconstruct.due_date,
+        }
+
+        self.assertEqual(result, expected_result)
 
     @parameterized.expand(
         [
             (
-                {
-                    "iban": "   SE45 5000 0000 0583 9825 7466",
-                    "reference": "12 34561",
-                    "euro_amount": 124.12,
-                    "due_date": date(2022, 2, 2),
-                },
-                InvalidIBANException,
-                "IBAN must be Finnish",
+                "692393900010033910000000295000000000000001357914991224",
+                InvalidSymbolException,
             ),
             (
-                {
-                    "iban": "FI495000942002XXXX",
-                    "reference": "7777776",
-                    "euro_amount": 2222.55,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidIBANException,
-                "Invalid IBAN",
+                "392393900010033910000000295000000000000001357914991224",
+                InvalidSymbolException,
             ),
             (
-                {
-                    "iban": 1234567,
-                    "reference": "7777776",
-                    "euro_amount": 2222.55,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidIBANException,
-                "IBAN must be string",
+                "4923939000100339100000002950000000000001357914991224",
+                InvalidLengthException,
             ),
             (
-                {
-                    "iban": "FI4950009420028730",
-                    "reference": 12345.123,
-                    "euro_amount": 2222.55,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidReferenceException,
-                "Invalid reference. Must be string or integer.",
+                "492393900010033910000000295000000000000000001357914991224",
+                InvalidLengthException,
             ),
             (
-                {
-                    "iban": "FI4950009420028730",
-                    "reference": "INVALID REFERENCE",
-                    "euro_amount": 2222.55,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidReferenceException,
-                "Invalid reference. Must use Finnish or RF reference formats.",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "RF07999999999993",
-                    "euro_amount": -1,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidEuroAmountException,
-                "Invalid euro amount. Amount must be positive.",
-            ),
-            (
-                {
-                    "iban": "FI49 5000 9420 0287 30",
-                    "reference": "RF07999999999993",
-                    "euro_amount": 1000000,
-                    "due_date": date(2020, 12, 12),
-                },
-                InvalidEuroAmountException,
-                "Invalid euro amount. Max value is 999999.99",
+                "492393900010033910000000295000000000000001357914999999",
+                ValueError,
             ),
         ]
     )
-    def test_invalid_virtuaaliviivakoodis(
-        self, options, expected_exception, expected_error_message
-    ):
-        with self.assertRaises(expected_exception) as context:
-            virtuaaliviivakoodi(**options)
-
-        raised_exception = context.exception
-        self.assertTrue(isinstance(raised_exception, VirtuaaliviivakoodiException))
-        self.assertEqual(str(raised_exception), expected_error_message)
+    def test_invalid_virtuaaliviivakoodis_deconstruct(self, virtuaaliviivakoodi, error):
+        with self.assertRaises(error):
+            deconstruct_virtuaaliviivakoodi(virtuaaliviivakoodi)

--- a/virtuaaliviivakoodi/__init__.py
+++ b/virtuaaliviivakoodi/__init__.py
@@ -1,1 +1,1 @@
-from .virtuaaliviivakoodi import virtuaaliviivakoodi
+from .virtuaaliviivakoodi import deconstruct_virtuaaliviivakoodi, virtuaaliviivakoodi

--- a/virtuaaliviivakoodi/constants/virtuaaliviivakoodi_slice.py
+++ b/virtuaaliviivakoodi/constants/virtuaaliviivakoodi_slice.py
@@ -1,0 +1,11 @@
+class VirtuaaliviivakoodiSlice:
+    # fmt: off
+    SYMBOL             = slice(0, 1)
+    IBAN               = slice(1, 17)
+    AMOUNT_EUROS       = slice(17, 23)
+    AMOUNT_CENTS       = slice(23, 25)
+    REFERENCE_FIN      = slice(28, 48)
+    REFERENCE_RF_HEAD  = slice(25, 27)
+    REFERENCE_RF_TAIL  = slice(27, 48)
+    DATE               = slice(48, 54)
+    # fmt: on

--- a/virtuaaliviivakoodi/dataclasses/__init__.py
+++ b/virtuaaliviivakoodi/dataclasses/__init__.py
@@ -1,0 +1,1 @@
+from .virtuaaliviivakoodi_deconstruct import VirtuaaliviivakoodiDeconstruct

--- a/virtuaaliviivakoodi/dataclasses/virtuaaliviivakoodi_deconstruct.py
+++ b/virtuaaliviivakoodi/dataclasses/virtuaaliviivakoodi_deconstruct.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from virtuaaliviivakoodi.constants import SymbolVersion
+
+
+@dataclass(frozen=True)
+class VirtuaaliviivakoodiDeconstruct:
+    symbol: SymbolVersion
+    iban: str
+    reference: str
+    euro_amount: Decimal
+    due_date: Optional[date]

--- a/virtuaaliviivakoodi/deconstructors/__init__.py
+++ b/virtuaaliviivakoodi/deconstructors/__init__.py
@@ -1,0 +1,4 @@
+from .amount import deconstruct_amount
+from .date import deconstruct_date
+from .iban import deconstruct_iban
+from .reference import deconstruct_reference_and_version

--- a/virtuaaliviivakoodi/deconstructors/amount.py
+++ b/virtuaaliviivakoodi/deconstructors/amount.py
@@ -1,0 +1,13 @@
+import decimal
+
+from virtuaaliviivakoodi.constants.virtuaaliviivakoodi_slice import (
+    VirtuaaliviivakoodiSlice,
+)
+
+
+def deconstruct_amount(virtuaaliviivakoodi: str) -> decimal.Decimal:
+
+    euros = virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.AMOUNT_EUROS]
+    cents = virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.AMOUNT_CENTS]
+
+    return decimal.Decimal(f"{euros}.{cents}")

--- a/virtuaaliviivakoodi/deconstructors/date.py
+++ b/virtuaaliviivakoodi/deconstructors/date.py
@@ -1,0 +1,30 @@
+from datetime import date, datetime
+from typing import Union
+
+from virtuaaliviivakoodi.constants.virtuaaliviivakoodi_slice import (
+    VirtuaaliviivakoodiSlice,
+)
+
+
+def deconstruct_date(virtuaaliviivakoodi: str) -> Union[date, None]:
+    """Deconstructs the due date from virtuaaliviivakoodi from "yymmdd" to datetime object.
+
+    The date can be not defined, in which case it is "000000" in the virtuaaliviivakoodi.
+    In this case None is returned.
+    """
+
+    due_date = virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.DATE]
+
+    if due_date == "000000":
+        return None
+
+    parsed_date = datetime.strptime(due_date, "%y%m%d").date()
+
+    # CASE: Virtuaaliviivakoodi's date is over the year 69
+    # Python's datetime assumes the year to be in the 1900s.
+    # > Need to manually validate that the year is in the current century.
+    # This is what you get for using 2-digit years.
+    if parsed_date.year < 2000:
+        parsed_date = parsed_date.replace(year=parsed_date.year + 100)
+
+    return parsed_date

--- a/virtuaaliviivakoodi/deconstructors/iban.py
+++ b/virtuaaliviivakoodi/deconstructors/iban.py
@@ -1,0 +1,9 @@
+from virtuaaliviivakoodi.constants.virtuaaliviivakoodi_slice import (
+    VirtuaaliviivakoodiSlice,
+)
+
+
+def deconstruct_iban(virtuaaliviivakoodi: str) -> str:
+    """Deconstructs the IBAN from virtuaaliviivakoodi"""
+
+    return "FI" + virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.IBAN]

--- a/virtuaaliviivakoodi/deconstructors/reference.py
+++ b/virtuaaliviivakoodi/deconstructors/reference.py
@@ -1,0 +1,37 @@
+from virtuaaliviivakoodi.constants import SymbolVersion
+from virtuaaliviivakoodi.constants.virtuaaliviivakoodi_slice import (
+    VirtuaaliviivakoodiSlice,
+)
+from virtuaaliviivakoodi.exceptions import InvalidSymbolException
+
+
+def deconstruct_reference_and_version(
+    virtuaaliviivakoodi: str,
+) -> tuple[str, SymbolVersion]:
+    """Returns the reference number in a human-readable format
+    and the version of the virtuaaliviivakoodi"""
+
+    reference: str
+    symbol_version: SymbolVersion
+
+    version = virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.SYMBOL]
+
+    if version not in [version.value for version in SymbolVersion]:
+        raise InvalidSymbolException("Invalid symbol version. Must be 4 or 5.")
+
+    if version == SymbolVersion.VERSION_4.value:
+        reference = virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.REFERENCE_FIN].lstrip(
+            "0"
+        )
+        symbol_version = SymbolVersion.VERSION_4
+    elif version == SymbolVersion.VERSION_5.value:
+        reference = (
+            "RF"
+            + virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.REFERENCE_RF_HEAD]
+            + virtuaaliviivakoodi[VirtuaaliviivakoodiSlice.REFERENCE_RF_TAIL].lstrip(
+                "0"
+            )
+        )
+        symbol_version = SymbolVersion.VERSION_5
+
+    return reference, symbol_version

--- a/virtuaaliviivakoodi/exceptions/__init__.py
+++ b/virtuaaliviivakoodi/exceptions/__init__.py
@@ -16,3 +16,11 @@ class InvalidEuroAmountException(VirtuaaliviivakoodiException):
 
 class InvalidDueDateException(VirtuaaliviivakoodiException):
     pass
+
+
+class InvalidSymbolException(VirtuaaliviivakoodiException):
+    pass
+
+
+class InvalidLengthException(VirtuaaliviivakoodiException):
+    pass

--- a/virtuaaliviivakoodi/normalizers/due_date.py
+++ b/virtuaaliviivakoodi/normalizers/due_date.py
@@ -1,10 +1,13 @@
 from datetime import date
+from typing import Union
 
 
-def normalize_due_date(due_date: date) -> str:
+def normalize_due_date(due_date: Union[date, None]) -> str:
     """
     Normalized due date into length 6 string.
     e.g. 2022-02-02 > "220202"
+
+    According to the documentation, the due date can be empty in which case 000000 is used.
     """
 
-    return due_date.strftime("%y%m%d")
+    return due_date.strftime("%y%m%d") if due_date else "000000"

--- a/virtuaaliviivakoodi/normalizers/euro_amount.py
+++ b/virtuaaliviivakoodi/normalizers/euro_amount.py
@@ -1,9 +1,10 @@
+import decimal
 from typing import Union
 
 from virtuaaliviivakoodi.utils import split_euros_and_cents
 
 
-def normalize_euro_amount(euro_amount: Union[float, int]) -> str:
+def normalize_euro_amount(euro_amount: Union[float, int, decimal.Decimal]) -> str:
     """
     Normalizes euro amount into length 8 string. E.g.
     123.23    > "00012323"

--- a/virtuaaliviivakoodi/utils/split_euros_and_cents.py
+++ b/virtuaaliviivakoodi/utils/split_euros_and_cents.py
@@ -1,8 +1,11 @@
+import decimal
 import math
-from typing import Tuple
+from typing import Tuple, Union
 
 
-def split_euros_and_cents(euro_amount: float) -> Tuple[int, int]:
+def split_euros_and_cents(
+    euro_amount: Union[float, int, decimal.Decimal]
+) -> Tuple[int, int]:
     cents_as_float, euros_as_float = math.modf(euro_amount)
     full_cents = int(round(cents_as_float * 100))
     full_euros = int(euros_as_float)

--- a/virtuaaliviivakoodi/validators/__init__.py
+++ b/virtuaaliviivakoodi/validators/__init__.py
@@ -1,4 +1,5 @@
 from .due_date import validate_due_date
 from .euro_amount import validate_euro_amount
 from .iban import validate_iban
+from .length import validate_length
 from .reference import validate_reference

--- a/virtuaaliviivakoodi/validators/due_date.py
+++ b/virtuaaliviivakoodi/validators/due_date.py
@@ -1,8 +1,11 @@
 from datetime import date
+from types import NoneType
+from typing import Union
 
 from virtuaaliviivakoodi.exceptions import InvalidDueDateException
 
 
-def validate_due_date(due_date: date) -> None:
-    if not isinstance(due_date, date):
+def validate_due_date(due_date: Union[date, None]) -> None:
+
+    if not isinstance(due_date, (date, NoneType)):
         raise InvalidDueDateException("Due date must be date object")

--- a/virtuaaliviivakoodi/validators/euro_amount.py
+++ b/virtuaaliviivakoodi/validators/euro_amount.py
@@ -1,16 +1,19 @@
+import decimal
 from typing import Union
 
 from virtuaaliviivakoodi.exceptions import InvalidEuroAmountException
 
 
-def validate_euro_amount(euro_amount: Union[float, int]) -> None:
-    if not isinstance(euro_amount, (float, int)):
-        raise InvalidEuroAmountException("Euro amount must be float or integer value")
+def validate_euro_amount(euro_amount: Union[float, int, decimal.Decimal]) -> None:
+    if not isinstance(euro_amount, (float, int, decimal.Decimal)):
+        raise InvalidEuroAmountException(
+            "Euro amount must be float, integer or decimal value"
+        )
 
     if euro_amount < 0:
         raise InvalidEuroAmountException(
             "Invalid euro amount. Amount must be positive."
         )
 
-    if euro_amount > 999999.99:
+    if euro_amount > decimal.Decimal("999999.99"):
         raise InvalidEuroAmountException("Invalid euro amount. Max value is 999999.99")

--- a/virtuaaliviivakoodi/validators/length.py
+++ b/virtuaaliviivakoodi/validators/length.py
@@ -1,0 +1,13 @@
+from virtuaaliviivakoodi.exceptions import InvalidLengthException
+
+
+def validate_length(virtuaaliviivakoodi: str) -> None:
+    """Validates the lenght of the virtuaaliviivakoodi.
+
+    The length of the virtuaaliviivakoodi must be 54 characters.
+    """
+
+    if len(virtuaaliviivakoodi) != 54:
+        raise InvalidLengthException(
+            "Invalid length of virtuaaliviivakoodi. Must be 54 characters."
+        )

--- a/virtuaaliviivakoodi/virtuaaliviivakoodi.py
+++ b/virtuaaliviivakoodi/virtuaaliviivakoodi.py
@@ -1,6 +1,14 @@
+import decimal
 from datetime import date
 from typing import Union
 
+from virtuaaliviivakoodi.dataclasses import VirtuaaliviivakoodiDeconstruct
+from virtuaaliviivakoodi.deconstructors import (
+    deconstruct_amount,
+    deconstruct_date,
+    deconstruct_iban,
+    deconstruct_reference_and_version,
+)
 from virtuaaliviivakoodi.normalizers import (
     normalize_due_date,
     normalize_euro_amount,
@@ -12,6 +20,7 @@ from virtuaaliviivakoodi.validators import (
     validate_due_date,
     validate_euro_amount,
     validate_iban,
+    validate_length,
     validate_reference,
 )
 
@@ -19,8 +28,8 @@ from virtuaaliviivakoodi.validators import (
 def virtuaaliviivakoodi(
     iban: str,
     reference: Union[int, str],
-    euro_amount: Union[float, int],
-    due_date: date,
+    euro_amount: Union[float, int, decimal.Decimal],
+    due_date: date = None,
 ) -> str:
     """Generates virtuaaliviivakoodi's based on Pankkiviivakoodi opas spec
     https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf
@@ -38,4 +47,32 @@ def virtuaaliviivakoodi(
         + normalize_euro_amount(euro_amount)
         + normalize_reference(reference)
         + normalize_due_date(due_date)
+    )
+
+
+def deconstruct_virtuaaliviivakoodi(
+    # pylint: disable=W0621
+    virtuaaliviivakoodi: str,
+) -> VirtuaaliviivakoodiDeconstruct:
+    """Deconstructs virtuaaliviivakoodi into its parts.
+
+    :param virtuaaliviivakoodi: Virtuaaliviivakoodi to deconstruct
+
+    :return: VirtuaaliviivakoodiDeconstruct object containing
+    the deconstructed parts of the virtuaaliviivakoodi
+    """
+
+    validate_length(virtuaaliviivakoodi)
+
+    reference, symbol = deconstruct_reference_and_version(virtuaaliviivakoodi)
+    iban = deconstruct_iban(virtuaaliviivakoodi)
+    euro_amount = deconstruct_amount(virtuaaliviivakoodi)
+    due_date = deconstruct_date(virtuaaliviivakoodi)
+
+    return VirtuaaliviivakoodiDeconstruct(
+        symbol=symbol,
+        iban=iban,
+        reference=reference,
+        euro_amount=decimal.Decimal(euro_amount),
+        due_date=due_date,
     )


### PR DESCRIPTION

#### New:

Added the feature to read the values from the virtuaaliviivakoodi. Returns the version number, IBAN, invoice amount, reference number and the  due date which are parsed from the virtuaaliviivakoodi. The version number is questionable if it is needed to be returned.

An assumption is made in `deconstruct_date.py` that all of the dates should be in the 2000s. Since virtuaaliviivakoodi uses 2-digit years Python would interpret some of the years to be from the 1900s.

#### Changes:
Added also the test cases found from the [Finannsi documentation](https://www.finanssiala.fi/wp-content/uploads/2021/03/Pankkiviivakoodi-opas.pdf) to the new parser and to the existing cases. This helped to find a bug. The current implementation didn't support leaving the date as empty which is mentioned in the documentation. Now the date can be left empty when constructing the virtuaaliviivakoodi and a value of `000000` is added as an empty date as specified by the standard.